### PR TITLE
fix(cooldowns): Subtract time difference correctly

### DIFF
--- a/src/cooldowns/CooldownManager.ts
+++ b/src/cooldowns/CooldownManager.ts
@@ -29,6 +29,6 @@ export class CooldownManager {
 
   public getCooldownRemaining(key) {
     if (!this.isOnCooldown(key)) return 0;
-    return Math.max(0, Date.now() - this.cooldowns.get(key)!);
+    return Math.max(0, this.cooldowns.get(key)! - Date.now());
   }
 }


### PR DESCRIPTION
The current release of Knub subtracts cooldowns using:
```ts
Math.max(0, Date.now() - this.cooldownManager.get(key)!);
```
Doing it as it is now would always return `0`, since the cooldown will always be greater than the current Date, hence flipping them would return the cooldown, and not `0` (unless there isn't a cooldown).
