### PR TITLE
feat: support em dashes for options

### DIFF
--- a/src/commands/PluginCommandManager.ts
+++ b/src/commands/PluginCommandManager.ts
@@ -32,6 +32,7 @@ export class PluginCommandManager<TPluginData extends AnyPluginData<any>> {
   constructor(client: Client, opts: PluginCommandManagerOpts = {}) {
     this.manager = new CommandManager<CommandContext<TPluginData>, CommandExtraData<TPluginData>>({
       prefix: opts.prefix ?? getDefaultPrefix(client),
+      optionPrefixes: ["-", "--", "—"],
     });
 
     this.handlers = new Map<number, CommandFn<TPluginData, any>>();


### PR DESCRIPTION
This pull request adds support for em dashes (`—`) for options, which on iOS, is automatically autocorrected from `--`. This should make it easier for iOS users on the chance they want to use `--` instead of `-`.