### PR TITLE
Add documentation for message commands

### DIFF
--- a/docs/docs/plugins/message-commands.md
+++ b/docs/docs/plugins/message-commands.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 7
+---
+
 ## Message commands
 
 Knub supports traditional message-based commands in addition to slash commands. Message commands are defined using plain JavaScript/TypeScript objects and follow a similar structure to slash commands, with built-in type safety and permission support.


### PR DESCRIPTION
adds a new documentation page describing how to define and use message-based commands in Knub