### PR TITLE
Add support for thread_type-based override matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knub",
-  "version": "32.0.0-next.24",
+  "version": "32.0.0-next.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "knub",
-      "version": "32.0.0-next.24",
+      "version": "32.0.0-next.25",
       "license": "MIT",
       "dependencies": {
         "discord-api-types": "^0.38.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knub",
-  "version": "32.0.0-next.24",
+  "version": "32.0.0-next.25",
   "description": "A bot framework for Discord",
   "author": "Miikka <contact@mivir.fi>",
   "license": "MIT",

--- a/src/config/PluginConfigManager.ts
+++ b/src/config/PluginConfigManager.ts
@@ -203,6 +203,12 @@ export class PluginConfigManager<TPluginData extends BasePluginData<BasePluginTy
       interaction?.channel?.isThread?.() ??
       null;
 
+    const threadType =
+      matchParams.threadType ??
+      (matchParams.channel?.isThread?.() ? (matchParams.channel.type === 12 ? "private" : "public") : null) ??
+      (message?.channel?.isThread?.() ? (message.channel.type === 12 ? "private" : "public") : null) ??
+      (interaction?.channel?.isThread?.() ? (interaction.channel.type === 12 ? "private" : "public") : null);
+
     // Passed member -> passed message's member -> passed interaction's member
     const member = matchParams.member || message?.member || interaction?.member;
 
@@ -219,6 +225,7 @@ export class PluginConfigManager<TPluginData extends BasePluginData<BasePluginTy
       categoryId,
       threadId,
       isThread,
+      threadType,
       memberRoles,
     };
 

--- a/src/config/configTypes.ts
+++ b/src/config/configTypes.ts
@@ -57,7 +57,7 @@ export const basePluginOverrideCriteriaSchema = z.strictObject({
     .nullable()
     .optional(),
   is_thread: z.boolean().nullable().optional(),
-  thread_type: z.literal(["public", "private"]).nullable().optional(),
+  thread_type: z.enum(["public", "private"]).nullable().optional(),
   extra: z.any().optional(),
 });
 

--- a/src/config/configUtils.ts
+++ b/src/config/configUtils.ts
@@ -18,6 +18,7 @@ export interface MatchParams<TExtra extends Record<string, unknown> = Record<str
   categoryId?: string | null;
   threadId?: string | null;
   isThread?: boolean | null;
+  threadType?: "public" | "private" | null;
   extra?: TExtra;
 }
 
@@ -215,6 +216,25 @@ export async function evaluateOverrideCriteria<TPluginData extends BasePluginDat
         return false;
       }
 
+      matchedOne = true;
+      continue;
+    }
+
+    // Match on thread type
+    // For a successful match, requires ANY of the specified types to match
+    if (key === "thread_type") {
+      const value = criteria[key]!;
+      const matchThreadType = matchParams.threadType;
+      if (matchThreadType) {
+        const types = Array.isArray(value) ? value : [value];
+        let match = false;
+        for (const t of types) {
+          match = match || matchThreadType === t;
+        }
+        if (!match) return false;
+      } else {
+        return false;
+      }
       matchedOne = true;
       continue;
     }


### PR DESCRIPTION
This enables conditional config like:
```yaml
  - is_thread: true
    thread_type: "private"
    config:
      can_peep: false
```